### PR TITLE
Fixed typographical error, changed auxilary to auxiliary in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The export process is configured through the only config, /etc/upstart-exporter.
     ---
     run_user: www # The user under which all installed through upstart-exporter background jobs are run
     run_group: www # The group of run_user
-    helper_dir: /var/helper_dir # Auxilary directory for scripts incapsulating background jobs
+    helper_dir: /var/helper_dir # Auxiliary directory for scripts incapsulating background jobs
     upstart_dir: /var/upstart_dir # Directory where upstart scripts should be placed
     prefix: 'myupstartjobs-' # Prefix added to app's log folders and upstart scripts
 


### PR DESCRIPTION
savonarola, I've corrected a typographical error in the documentation of the [upstart-exporter](https://github.com/savonarola/upstart-exporter) project. You should be able to merge this pull request automatically. However, if this was intentional or you enjoy living in linguistic squalor please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.